### PR TITLE
feat: switch to mley health plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@capacitor/local-notifications": "^7.0.1",
         "@capacitor/push-notifications": "^7.0.1",
         "@hookform/resolvers": "^5.2.0",
-        "@perfood/capacitor-healthkit": "^1.3.2",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.1",
         "@radix-ui/react-aspect-ratio": "^1.1.0",
@@ -66,7 +65,8 @@
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.3",
-        "zod": "^4.0.10"
+        "zod": "^4.0.10",
+        "@mley/capacitor-health": "^1.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -1465,15 +1465,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@perfood/capacitor-healthkit": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@perfood/capacitor-healthkit/-/capacitor-healthkit-1.3.2.tgz",
-      "integrity": "sha512-c9e8JBmp44k6/NygZpTzDV8NWE69+XeM2NKebvUMvhsh8JcUVOfcs+Fzx+UeOrJxV1JiJ27TrvGAyHW2/+NUmQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@capacitor/core": "^4.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -8197,6 +8188,9 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/@mley/capacitor-health": {
+      "version": "^1.0.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@capacitor/local-notifications": "^7.0.1",
     "@capacitor/push-notifications": "^7.0.1",
     "@hookform/resolvers": "^5.2.0",
-    "@perfood/capacitor-healthkit": "^1.3.2",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.1",
     "@radix-ui/react-aspect-ratio": "^1.1.0",
@@ -70,7 +69,8 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^4.0.10"
+    "zod": "^4.0.10",
+    "@mley/capacitor-health": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/hooks/useHealthIntegration.ts
+++ b/src/hooks/useHealthIntegration.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from './useAuth';
 import { supabase } from '@/integrations/supabase/client';
-import { perfoodHealthService, HealthKitSampleNames } from '@/services/perfoodHealthService';
+import { mleyHealthService, MleySampleNames } from '@/services/mleyHealthService';
 import { healthKitLogger } from '@/services/healthKitLogger';
 import { toast } from 'sonner';
 
@@ -46,7 +46,7 @@ export interface HealthIntegrationState {
 
 export const useHealthIntegration = () => {
   const { user } = useAuth();
-  const isNative = perfoodHealthService.getIsNative();
+  const isNative = mleyHealthService.getIsNative();
   
   const [state, setState] = useState<HealthIntegrationState>({
     isAvailable: false,
@@ -58,7 +58,7 @@ export const useHealthIntegration = () => {
   });
 
   const initializeHealthIntegration = useCallback(async () => {
-    await healthKitLogger.info('useHealthIntegration', 'initializeHealthIntegration', 'Starting initialization', {}, perfoodHealthService.getIsNative() ? 'mobile' : 'web', isNative);
+    await healthKitLogger.info('useHealthIntegration', 'initializeHealthIntegration', 'Starting initialization', {}, mleyHealthService.getIsNative() ? 'mobile' : 'web', isNative);
     
     // Skip initialization on web platform
     if (!isNative) {
@@ -74,9 +74,9 @@ export const useHealthIntegration = () => {
     
     try {
       setState(prev => ({ ...prev, status: 'initializing' }));
-      await healthKitLogger.info('useHealthIntegration', 'initializeHealthIntegration', 'Calling perfoodHealthService.initialize...', {}, 'mobile', isNative);
+      await healthKitLogger.info('useHealthIntegration', 'initializeHealthIntegration', 'Calling mleyHealthService.initialize...', {}, 'mobile', isNative);
       
-      const available = await perfoodHealthService.initialize();
+      const available = await mleyHealthService.initialize();
       await healthKitLogger.info('useHealthIntegration', 'initializeHealthIntegration', 'Service initialized', { available }, 'mobile', isNative);
       
       if (available) {
@@ -175,9 +175,9 @@ export const useHealthIntegration = () => {
         all: []
       };
 
-      await healthKitLogger.info('useHealthIntegration', 'requestPermissions', 'About to call perfoodHealthService.requestPermissions', { permissions }, 'mobile', isNative);
-      const success = await perfoodHealthService.requestPermissions(permissions);
-      await healthKitLogger.info('useHealthIntegration', 'requestPermissions', 'perfoodHealthService.requestPermissions completed', { success }, 'mobile', isNative);
+      await healthKitLogger.info('useHealthIntegration', 'requestPermissions', 'About to call mleyHealthService.requestPermissions', { permissions }, 'mobile', isNative);
+      const success = await mleyHealthService.requestPermissions(permissions);
+      await healthKitLogger.info('useHealthIntegration', 'requestPermissions', 'mleyHealthService.requestPermissions completed', { success }, 'mobile', isNative);
       
       if (success) {
         setState(prev => ({
@@ -249,7 +249,7 @@ export const useHealthIntegration = () => {
         await healthKitLogger.info('useHealthIntegration', 'syncHealthData', 'About to fetch data', { dataType }, 'mobile', isNative);
         
         try {
-          const data = await perfoodHealthService.queryHealthData(dataType, startDate, endDate);
+          const data = await mleyHealthService.queryAggregatedData(dataType, startDate, endDate, 'day');
           await healthKitLogger.info('useHealthIntegration', 'syncHealthData', 'Fetched data points', { 
             dataType, 
             count: data.length,
@@ -367,23 +367,23 @@ export const useHealthIntegration = () => {
   const getDataTypeForPermission = (permission: HealthDataType): string | null => {
     switch (permission) {
       case HealthDataType.STEPS:
-        return HealthKitSampleNames.STEP_COUNT;
+        return MleySampleNames.STEPS;
       case HealthDataType.DISTANCE:
-        return HealthKitSampleNames.DISTANCE_WALKING_RUNNING;
+        return MleySampleNames.DISTANCE;
       case HealthDataType.CALORIES:
-        return HealthKitSampleNames.ACTIVE_ENERGY_BURNED;
+        return MleySampleNames.CALORIES_ACTIVE;
       case HealthDataType.HEART_RATE:
-        return HealthKitSampleNames.HEART_RATE;
+        return MleySampleNames.HEART_RATE;
       case HealthDataType.WEIGHT:
-        return HealthKitSampleNames.BODY_MASS;
+        return MleySampleNames.WEIGHT;
       case HealthDataType.HEIGHT:
-        return HealthKitSampleNames.HEIGHT;
+        return MleySampleNames.HEIGHT;
       case HealthDataType.SLEEP:
-        return HealthKitSampleNames.SLEEP_ANALYSIS;
+        return MleySampleNames.SLEEP;
       case HealthDataType.WATER:
-        return HealthKitSampleNames.DIETARY_WATER;
+        return MleySampleNames.WATER;
       case HealthDataType.WORKOUT:
-        return HealthKitSampleNames.WORKOUT_TYPE;
+        return MleySampleNames.WORKOUT;
       default:
         return null;
     }

--- a/src/services/healthSyncService.ts
+++ b/src/services/healthSyncService.ts
@@ -1,6 +1,5 @@
-import { Capacitor } from '@capacitor/core';
 import { supabase } from '@/integrations/supabase/client';
-import { perfoodHealthService, HealthKitSampleNames } from './perfoodHealthService';
+import { mleyHealthService } from './mleyHealthService';
 
 export interface SyncConfig {
   enabledDataTypes: string[];
@@ -35,7 +34,7 @@ export class HealthSyncService {
     console.log('Starting background health sync with config:', config);
     
     // Initialize health service first
-    const isAvailable = await perfoodHealthService.initialize();
+    const isAvailable = await mleyHealthService.initialize();
     if (!isAvailable) {
       console.warn('Health service not available, sync will use mock data');
     }
@@ -90,7 +89,7 @@ export class HealthSyncService {
       // Fetch data for each enabled type using Perfood Health
       for (const dataType of config.enabledDataTypes) {
         try {
-          const data = await perfoodHealthService.queryHealthData(dataType, startDate, endDate);
+          const data = await mleyHealthService.queryAggregatedData(dataType, startDate, endDate, 'hour');
           
           // Convert to our format
           const convertedData = data.map(item => ({

--- a/src/services/mleyHealthService.ts
+++ b/src/services/mleyHealthService.ts
@@ -1,0 +1,98 @@
+import { Capacitor } from '@capacitor/core';
+import { CapacitorHealth } from '@mley/capacitor-health';
+import { healthKitLogger } from './healthKitLogger';
+
+export interface HealthDataPoint {
+  type: string;
+  value: number;
+  unit: string;
+  startDate: Date;
+  endDate: Date;
+  sourceName?: string;
+}
+
+export const MleySampleNames = {
+  STEPS: 'steps',
+  DISTANCE: 'distance',
+  CALORIES_ACTIVE: 'calories.active',
+  CALORIES_BASAL: 'calories.basal',
+  HEART_RATE: 'heart_rate',
+  WEIGHT: 'weight',
+  HEIGHT: 'height',
+  SLEEP: 'sleep',
+  WORKOUT: 'activity',
+  WATER: 'water'
+} as const;
+
+class MleyHealthService {
+  private isNative: boolean;
+  private initialized = false;
+
+  constructor() {
+    this.isNative = Capacitor.isNativePlatform();
+  }
+
+  async initialize(): Promise<boolean> {
+    if (!this.isNative) {
+      return false;
+    }
+    try {
+      await CapacitorHealth.initialize();
+      this.initialized = true;
+      return true;
+    } catch (err) {
+      await healthKitLogger.error('MleyHealthService', 'initialize', 'Failed to initialize', (err as Error).message);
+      this.initialized = false;
+      return false;
+    }
+  }
+
+  async requestPermissions(permissions: string[]): Promise<boolean> {
+    if (!this.isNative) {
+      return false;
+    }
+    try {
+      await CapacitorHealth.requestPermissions({ read: permissions });
+      return true;
+    } catch (err) {
+      await healthKitLogger.error('MleyHealthService', 'requestPermissions', 'Failed to request permissions', (err as Error).message);
+      return false;
+    }
+  }
+
+  async queryAggregatedData(dataType: string, startDate: Date, endDate: Date, bucket: 'day' | 'hour' = 'day'): Promise<HealthDataPoint[]> {
+    if (!this.isNative) {
+      return [];
+    }
+    try {
+      const result: any = await CapacitorHealth.queryAggregatedData({
+        dataType,
+        startDate: startDate.toISOString(),
+        endDate: endDate.toISOString(),
+        bucket
+      });
+
+      if (!result || !Array.isArray(result.data)) {
+        return [];
+      }
+
+      return result.data.map((item: any) => ({
+        type: dataType,
+        value: item.value,
+        unit: item.unit,
+        startDate: new Date(item.startTime || item.startDate),
+        endDate: new Date(item.endTime || item.endDate),
+        sourceName: item.source
+      }));
+    } catch (err) {
+      await healthKitLogger.error('MleyHealthService', 'queryAggregatedData', 'Query failed', (err as Error).message);
+      return [];
+    }
+  }
+
+  getIsNative(): boolean {
+    return this.isNative;
+  }
+}
+
+export const mleyHealthService = new MleyHealthService();


### PR DESCRIPTION
## Summary
- replace Perfood HealthKit dependency with @mley/capacitor-health
- add mleyHealthService with initialization, permission and aggregated query helpers
- update health integration and sync services to use aggregated data buckets

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx cap sync ios` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cap)*
- `npx cap sync android` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cap)*

------
https://chatgpt.com/codex/tasks/task_e_68964553aa748323bf3e714a1599362b