### PR TITLE
docs: clarify preview build steps

### DIFF
--- a/.github/workflows/FastlaneV3.yml
+++ b/.github/workflows/FastlaneV3.yml
@@ -37,7 +37,7 @@ jobs:
           node-version: 20
 
       - run: npm install --legacy-peer-deps
-      - run: NODE_ENV=production npm run build:cap
+      - run: NODE_ENV=production npm run build
 
       - run: rm -rf ios
       - run: |

--- a/.github/workflows/FastlaneV4.yml
+++ b/.github/workflows/FastlaneV4.yml
@@ -37,7 +37,7 @@ jobs:
           node-version: 20
 
       - run: npm install --legacy-peer-deps
-      - run: NODE_ENV=production npm run build:cap
+      - run: NODE_ENV=production npm run build
 
       - run: rm -rf ios
       - run: |

--- a/README.md
+++ b/README.md
@@ -38,11 +38,14 @@ npm run dev
 
 ## Building the project
 
-Run `npm run build` to generate the production build in the `build/` directory.
+Run `npm run build` to automatically choose the correct build target for the current platform. In web preview environments this outputs to the `dist/` directory, while mobile previews (iOS/Android) output to the `www/` directory.
 
-For a Capacitor build, run `npm run build:cap` to output to the `www/` directory.
+To force a specific target:
 
-These `build` and `www` directories are generated and not committed to source control.
+- `npm run build:web` – always build the web preview (`dist/`).
+- `npm run build:cap` – build using Capacitor (`www/`).
+
+These `dist` and `www` directories are generated and not committed to source control.
 
 
 **Edit a file directly in GitHub**

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "node scripts/build.mjs",
+    "build:web": "vite build",
     "build:dev": "vite build --mode development",
     "build:cap": "BUILD_TARGET=capacitor vite build",
     "lint": "eslint .",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,10 @@
+import { execSync } from 'node:child_process';
+
+const env = { ...process.env };
+const platform = (process.env.RUNNER_OS || process.platform).toLowerCase();
+
+if (!env.BUILD_TARGET && (platform.includes('mac') || platform.includes('ios') || platform.includes('android'))) {
+  env.BUILD_TARGET = 'capacitor';
+}
+
+execSync('vite build', { stdio: 'inherit', env });


### PR DESCRIPTION
## Summary
- add build script that auto-selects capacitor target on mobile runners
- document preview build commands and directories
- ensure CI workflows use the unified build script

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm run build:web` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a882e6ae48832391ab2183e998529a